### PR TITLE
Use spread operator to fix cond function in JS

### DIFF
--- a/src/javascript/lib/core/special_forms.js
+++ b/src/javascript/lib/core/special_forms.js
@@ -4,7 +4,7 @@ function _case(condition, clauses) {
   return Core.Patterns.defmatch(...clauses)(condition);
 }
 
-function cond(clauses) {
+function cond(...clauses) {
   for (const clause of clauses) {
     if (clause[0]) {
       return clause[1]();

--- a/src/javascript/tests/cond.spec.js
+++ b/src/javascript/tests/cond.spec.js
@@ -10,7 +10,7 @@ test('cond', t => {
     [true, () => 'This will'],
   ];
 
-  const result = SpecialForms.cond(clauses);
+  const result = SpecialForms.cond(...clauses);
 
   t.is(result, 'This will');
 });


### PR DESCRIPTION
I noticed that converting `cond` in Elixirscript was broken because `Bootstrap.Core.SpecialForms.cond` would be called with `clauses` as arguments instead of an array.

For instance this Elixir code...

```elixir
val = cond do
  1 == 1 -> "A"
  1 == 2 -> "B"
end
```

Would be converted into...

```javscript
Bootstrap.Core.SpecialForms.cond(
    [
        Bootstrap.Core.erlang.equal(1, 1),
        () => {
        return 'A'
        }
    ],
    [
        Bootstrap.Core.erlang.equal(1, 2),
        () => {
        return 'B'
        }
    ]
))
```

But the [JS `cond` function](https://github.com/elixirscript/elixirscript/blob/master/src/javascript/lib/core/special_forms.js#L7) expects a single array argument.

The fix is as simple as using the JS spread operator to convert `clauses` into an array. That said, maybe it would be more appropriate to fix this at the Elixirscript compilation level, rather than inside the JS library?

I also wonder if it would be more helpful to structure the tests so that they're running `ElixirScript.Compiler.compile` to take Elixirscript as input, run the output JS (via shelling out `System.cmd "node", ["-e #{js_code}"]`?), and asserting the result of the JS output? That might help provide coverage for issues like this where the compiled Elixirscript code doesn't match up with the JS library code.

I'm new to contribuiting to compilers so I'm just throwing out ideas. Looking forward to hearing your feedback!