### PR TITLE
Fix compilation of functions that return an array

### DIFF
--- a/lib/elixir_script/passes/translate/function.ex
+++ b/lib/elixir_script/passes/translate/function.ex
@@ -137,7 +137,7 @@ defmodule ElixirScript.Translate.Function do
         List.flatten(list)
       b when is_list(b) ->
         {list, _} = Enum.map_reduce(b, state, &Form.compile(&1, &2))
-        List.flatten(list)
+        J.array_expression(list)
       _ ->
         Form.compile!(body, state)
     end

--- a/test/passes/translate/form_test.exs
+++ b/test/passes/translate/form_test.exs
@@ -118,4 +118,17 @@ defmodule ElixirScript.Translate.Forms.Test do
     )
   end
 
+  test "function returning an array" do
+    ast = {:fn, [], [{:foo, [], [], [1, 2, 3]}]}
+    state = %{}
+
+    {js_ast, _} = Form.compile(ast, state)
+    return_statement = Enum.at(Enum.at(js_ast.body.body, 1).consequent.body, 1)
+
+    assert return_statement.argument == J.array_expression([
+      J.literal(1),
+      J.literal(2),
+      J.literal(3)
+    ])
+  end
 end


### PR DESCRIPTION
Given this ElixirScript code...

````elixir
defmodule Foo do
  def foo do
    [1,2,3]
  end
end

defmodule Main do
  def start(_, _) do
    JS.console.log Foo.foo # Returns `3`
  end
end
````

It would compile code like....

````javascript
if (...) {
    const [_0] = __arg_matches__;

    1

    2

    return 3;
}
````

When it should compile like...

````javascript
if (...) {
    const [_0] = __arg_matches__;

    return [1, 2, 3];
}
````

This fixes that by wrapping the `body` of `compile_clause` in `J.array_expression`.