### PR TITLE
specify node.js version required in README.md

### DIFF
--- a/GettingStarted.md
+++ b/GettingStarted.md
@@ -61,4 +61,4 @@ Elixirscript supports all macros
 
 ### JavaScript Interop
 
-Check out the [JavaScript Interoperability](JavaScriptInterop.html) documentation
+Check out the [JavaScript Interoperability](JavascriptInterop.html) documentation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Requirements
 ===========
 * Erlang 20 or greater
 * Elixir 1.5 or greater (must be compiled with Erlang 20 or greater)
-* Node (only for development)
+* Node 8.2.1 or greater (only for development)
 
 Usage
 ========


### PR DESCRIPTION
Seems the tests and other random things fail without a recent Node.js version.