### PR TITLE
default make will check deps first before compile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: compile test clean js_compile elixir_compile elixir_test js_test deps elixir_deps js_deps
 
-default: compile
+default: deps compile
 
 compile: js_compile elixir_compile
 


### PR DESCRIPTION
If we run make in a clean checkout, we will get errors due to missing deps. IMO the default behavior should make sure all deps are in place before attempting to compile.