### PR TITLE
Add in grapheme-splitter library

### DIFF
--- a/lib/elixir_script/lib/functions.ex
+++ b/lib/elixir_script/lib/functions.ex
@@ -3,4 +3,6 @@ defmodule ElixirScript.Core.Functions do
   use ElixirScript.FFI, global: true
 
   defexternal split_at(value, position)
+
+  defexternal graphemes(str)
 end

--- a/lib/elixir_script/lib/string.ex
+++ b/lib/elixir_script/lib/string.ex
@@ -90,7 +90,7 @@ defmodule ElixirScript.String do
   end
 
   def length(str) do
-    str.length()
+    graphemes(str).length()
   end
 
   def match?(str, regex) do

--- a/lib/elixir_script/lib/string.ex
+++ b/lib/elixir_script/lib/string.ex
@@ -86,7 +86,7 @@ defmodule ElixirScript.String do
   end
 
   def graphemes(str) do
-    str.split('')
+    ElixirScript.Core.Functions.graphemes(str)
   end
 
   def length(str) do

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "license": "MIT",
   "dependencies": {
     "erlang-types": "^1.0.1",
+    "grapheme-splitter": "^1.0.2",
+    "rollup-plugin-commonjs": "^8.2.1",
     "tailored": "^2.7.2"
   },
   "devDependencies": {
-    "@std/esm": "^0.5.1",
+    "@std/esm": "^0.8.3",
     "ava": "^0.21.0",
     "babel-core": "^6.24.0",
     "babel-preset-env": "^1.6.0",
@@ -40,7 +42,9 @@
     "sinon": "^2.4.1"
   },
   "ava": {
-    "require": ["babel-register"],
+    "require": [
+      "babel-register"
+    ],
     "babel": {
       "babelrc": true
     }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import nodeResolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
 import babel from 'rollup-plugin-babel';
 import minify from 'rollup-plugin-babel-minify';
 
@@ -6,7 +7,11 @@ export default {
   entry: 'src/javascript/elixir.js',
   moduleName: 'ElixirScript',
   plugins: [
-    nodeResolve({ jsnext: true }),
+    nodeResolve({
+      jsnext: true,
+      main: true,
+    }),
+    commonjs(),
     babel({
       babelrc: false,
     }),

--- a/src/javascript/lib/core/functions.js
+++ b/src/javascript/lib/core/functions.js
@@ -1,3 +1,4 @@
+import GraphemeSplitter from 'grapheme-splitter';
 import Protocol from './protocol';
 import Core from '../core';
 import proplists from './erlang_compat/proplists';
@@ -163,8 +164,11 @@ function trampoline(f) {
 }
 
 function split_at(value, position) {
+  const splitter = new GraphemeSplitter();
+  const splitValues = splitter.splitGraphemes(value);
+
   if (position < 0) {
-    const newPosition = value.length + position;
+    const newPosition = splitValues.length + position;
     if (newPosition < 0) {
       return new Core.Tuple('', value);
     }
@@ -176,7 +180,7 @@ function split_at(value, position) {
   let second = '';
   let index = 0;
 
-  for (const character of value) {
+  for (const character of splitValues) {
     if (index < position) {
       first += character;
     } else {
@@ -189,6 +193,11 @@ function split_at(value, position) {
   return new Core.Tuple(first, second);
 }
 
+function graphemes(str) {
+  const splitter = new GraphemeSplitter();
+  return splitter.splitGraphemes(str);
+}
+
 export default {
   call_property,
   defprotocol,
@@ -199,4 +208,5 @@ export default {
   trampoline,
   Recurse,
   split_at,
+  graphemes,
 };

--- a/src/javascript/tests/core/functions.spec.js
+++ b/src/javascript/tests/core/functions.spec.js
@@ -21,6 +21,7 @@ test('split_at', (t) => {
   t.deepEqual(Functions.split_at('abc', 1000).values, ['abc', '']);
   t.deepEqual(Functions.split_at('abc', -1000).values, ['', 'abc']);
   t.deepEqual(Functions.split_at('😀abélkm', 4).values, ['😀abé', 'lkm']);
+  t.deepEqual(Functions.split_at('👨‍👩‍👦‍👦abélkm', 4).values, ['👨‍👩‍👦‍👦abé', 'lkm']);
 });
 
 test('map_to_object/1', (t) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -48,9 +48,9 @@
   dependencies:
     arrify "^1.0.1"
 
-"@std/esm@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.5.1.tgz#5d9c855c1ce68401bd235b835a4fc609b1a8df26"
+"@std/esm@^0.8.3":
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/@std/esm/-/esm-0.8.3.tgz#7a3c3144ca0905c9b92d82b79987503ecb58a193"
 
 abbrev@1:
   version "1.1.0"
@@ -69,6 +69,10 @@ acorn@^3.0.4:
 acorn@^5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+acorn@^5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
 ajv-keywords@^1.0.0:
   version "1.5.1"
@@ -1664,6 +1668,14 @@ estree-walker@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
 
+estree-walker@^0.3.0:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.3.1.tgz#e6b1a51cf7292524e7237c312e5fe6660c1ce1aa"
+
+estree-walker@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.0.tgz#aae3b57c42deb8010e349c892462f0e71c5dd1aa"
+
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
@@ -1991,6 +2003,10 @@ got@^6.7.1:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+grapheme-splitter@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/grapheme-splitter/-/grapheme-splitter-1.0.2.tgz#639e9dc1bf065892c643de31daa27cf58b1068e2"
 
 handlebars@^4.0.3:
   version "4.0.10"
@@ -2628,6 +2644,12 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
+
+magic-string@^0.22.4:
+  version "0.22.4"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.22.4.tgz#31039b4e40366395618c1d6cf8193c53917475ff"
+  dependencies:
+    vlq "^0.2.1"
 
 make-dir@^1.0.0:
   version "1.0.0"
@@ -3389,6 +3411,12 @@ resolve@^1.1.6, resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -3425,6 +3453,16 @@ rollup-plugin-babel@^2.7.1:
     object-assign "^4.1.0"
     rollup-pluginutils "^1.5.0"
 
+rollup-plugin-commonjs@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.2.1.tgz#5e40c78375eb163c14c76bce69da1750e5905a2e"
+  dependencies:
+    acorn "^5.1.1"
+    estree-walker "^0.5.0"
+    magic-string "^0.22.4"
+    resolve "^1.4.0"
+    rollup-pluginutils "^2.0.1"
+
 rollup-plugin-node-resolve@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz#8b897c4c3030d5001277b0514b25d2ca09683ee0"
@@ -3440,6 +3478,13 @@ rollup-pluginutils@^1.5.0:
   dependencies:
     estree-walker "^0.2.1"
     minimatch "^3.0.2"
+
+rollup-pluginutils@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz#7ec95b3573f6543a46a6461bd9a7c544525d0fc0"
+  dependencies:
+    estree-walker "^0.3.0"
+    micromatch "^2.3.11"
 
 rollup@^0.45.2:
   version "0.45.2"
@@ -3929,6 +3974,10 @@ verror@1.3.6:
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
     extsprintf "1.0.2"
+
+vlq@^0.2.1:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.2.tgz#e316d5257b40b86bb43cb8d5fea5d7f54d6b0ca1"
 
 well-known-symbols@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This is used to make sure that ElixirScript correctly splits
unicode characters

fixes #353 