### PR TITLE
enforce node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "elixirscript": "./elixirscript"
   },
+  "engines": {
+    "node": ">=7.1"
+  },
   "scripts": {
     "lint": "eslint src/javascript/lib/**/*.js src/javascript/tests/**/*.js",
     "lint:fix": "eslint src/javascript/lib/**/*.js src/javascript/tests/**/*.js --fix",


### PR DESCRIPTION
fixes https://github.com/elixirscript/elixirscript/issues/401.

I am not sure what the minimum node.js version needs to be, async functions got added in Node 8, perhaps it has to be Node 8?