### PR TITLE
Add map functions to check for equality of keys

### DIFF
--- a/src/javascript/lib/core/erlang_compat/maps.js
+++ b/src/javascript/lib/core/erlang_compat/maps.js
@@ -13,7 +13,8 @@ function is_non_primitive(key) {
     erlang.is_map(key) ||
     erlang.is_pid(key) ||
     erlang.is_reference(key) ||
-    erlang.is_bitstring(key)
+    erlang.is_bitstring(key) ||
+    erlang.is_tuple(key)
   );
 }
 

--- a/src/javascript/lib/core/erlang_compat/maps.js
+++ b/src/javascript/lib/core/erlang_compat/maps.js
@@ -7,12 +7,62 @@ const ERROR = Symbol.for('error');
 const BADMAP = Symbol.for('badmap');
 const BADKEY = Symbol.for('badkey');
 
+function is_non_primitive(key) {
+  return (
+    erlang.is_list(key) ||
+    erlang.is_map(key) ||
+    erlang.is_pid(key) ||
+    erlang.is_reference(key) ||
+    erlang.is_bitstring(key)
+  );
+}
+
+function __has(map, key) {
+  if (is_non_primitive(key)) {
+    for (const map_key of map.keys()) {
+      if (erlang.equals(map_key, key)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  return map.has(key);
+}
+
+function __get(map, key) {
+  if (is_non_primitive(key)) {
+    for (const map_key of map.keys()) {
+      if (erlang.equals(map_key, key)) {
+        return map.get(map_key);
+      }
+    }
+
+    return null;
+  }
+
+  return map.get(key);
+}
+
+function __delete(map, key) {
+  if (is_non_primitive(key)) {
+    for (const map_key of map.keys()) {
+      if (erlang.equals(map_key, key)) {
+        map.delete(map_key);
+      }
+    }
+  } else {
+    map.delete(key);
+  }
+}
+
 function find(key, map) {
   if (erlang.is_map(map) === false) {
     return new ErlangTypes.Tuple(BADMAP, map);
   }
 
-  const value = map.get(key);
+  const value = __get(map, key);
 
   if (typeof value !== 'undefined') {
     return new ErlangTypes.Tuple(OK, value);
@@ -38,7 +88,7 @@ function remove(key, map1) {
 
   const map2 = new Map(map1);
 
-  map2.delete(key);
+  __delete(map2, key);
 
   return map2;
 }
@@ -83,7 +133,7 @@ function values(map) {
 }
 
 function is_key(key, map) {
-  return map.has(key);
+  return __has(map, key);
 }
 
 function put(key, value, map1) {
@@ -130,7 +180,7 @@ function get(...args) {
   }
 
   if (is_key(key)) {
-    return map.get(key);
+    return __get(map, key);
   }
 
   if (args.length === 3) {
@@ -149,9 +199,9 @@ function take(key, map1) {
     return ERROR;
   }
 
-  const value = map1.get(key);
+  const value = __get(map1, key);
   const map2 = new Map(map1);
-  map2.delete(key);
+  __delete(map2, key);
 
   return new ErlangTypes.Tuple(value, map2);
 }
@@ -170,4 +220,5 @@ export default {
   update,
   get,
   take,
+  __has,
 };

--- a/src/javascript/tests/core/erlang_compat/maps_spec.js
+++ b/src/javascript/tests/core/erlang_compat/maps_spec.js
@@ -13,10 +13,37 @@ test('find', (t) => {
   myMap = new Map([['t', 'b']]);
   result = Core.maps.find('t', myMap);
   t.deepEqual(result.values, [Symbol.for('ok'), 'b']);
+
+  myMap = new Map([[[1], 'b']]);
+  result = Core.maps.find([1], myMap);
+  t.deepEqual(result.values, [Symbol.for('ok'), 'b']);
+
+  myMap = new Map([[new Map(), 'b']]);
+  result = Core.maps.find(new Map(), myMap);
+  t.deepEqual(result.values, [Symbol.for('ok'), 'b']);
 });
 
 test('fold', (t) => {
   const myMap = new Map([['a', 1], ['b', 2]]);
   const result = Core.maps.fold((k, v, acc) => acc + v, 0, myMap);
   t.is(result, 3);
+});
+
+test('is_key', (t) => {
+  const myMap = new Map([['a', 1], ['b', 2]]);
+  let result = Core.maps.is_key('a', myMap);
+  t.is(result, true);
+
+  result = Core.maps.is_key('c', myMap);
+  t.is(result, false);
+});
+
+test('remove', (t) => {
+  let myMap = new Map([['a', 1], ['b', 2]]);
+  let result = Core.maps.remove('a', myMap);
+  t.is(result.has('a'), false);
+
+  myMap = new Map([[[1], 1], ['b', 2]]);
+  result = Core.maps.remove([1], myMap);
+  t.is(Core.maps.__has(result, [1]), false);
 });


### PR DESCRIPTION
This is done because map key equality does not work for maps,
arrays, tuples, or anything else not a number, string or symbol

fixes #406