### PR TITLE
Add filename.join/1

### DIFF
--- a/src/javascript/lib/core.js
+++ b/src/javascript/lib/core.js
@@ -8,6 +8,7 @@ import lists from './core/erlang_compat/lists';
 import elixir_errors from './core/erlang_compat/elixir_errors';
 import elixir_config from './core/erlang_compat/elixir_config';
 import io from './core/erlang_compat/io';
+import filename from './core/erlang_compat/filename';
 import binary from './core/erlang_compat/binary';
 import unicode from './core/erlang_compat/unicode';
 import Store from './core/store';
@@ -64,6 +65,7 @@ export default {
   lists,
   elixir_errors,
   io,
+  filename,
   binary,
   unicode,
   elixir_config,

--- a/src/javascript/lib/core/erlang_compat/filename.js
+++ b/src/javascript/lib/core/erlang_compat/filename.js
@@ -1,0 +1,18 @@
+function join(arg = [], extra = []) {
+  let components = Array.isArray(arg) ? arg : [arg];
+  components = components.concat(extra)
+  let names = [];
+  for (let i = components.length - 1; i >= 0; i--) {
+    const name = components[i];
+    const normalized_name = name.replace(/\/+/g, '/').replace(/^\/|\/$/g, '');
+    names.push(normalized_name);
+    if (name[0] == '/') {
+      names.push('');
+      break;
+    }
+  }
+  return names.reverse().join('/');
+}
+export default {
+  join,
+};

--- a/src/javascript/tests/core/erlang_compat/filename_spec.js
+++ b/src/javascript/tests/core/erlang_compat/filename_spec.js
@@ -1,0 +1,13 @@
+import test from 'ava';
+import Core from '../../../lib/core';
+
+test('join/1', (t) => {
+  let result = Core.filename.join(['/usr', 'local', 'bin']);
+  t.is(result, '/usr/local/bin');
+
+  result = Core.filename.join(['a', '///b/', 'c/']);
+  t.is(result, '/b/c');
+
+  result = Core.filename.join(['a/b///c/']);
+  t.is(result, 'a/b/c');
+});


### PR DESCRIPTION
Hello,

Per #306 this PR adds support for `filename.join/1` which should work with unix file paths. However, I'm not sure how to approach compatibility with Windows paths (e.g. the use of `\\` instead of `/`).

First step would be detecting the underlying OS, which requires different methods depending if we're running in a browser environment or a node server.

For the browser method, I think parsing the `window.navigator.platform` might do it but I'm not sure if this would be the best approach.