### PR TITLE
Fix broken link

### DIFF
--- a/lib/elixir_script.ex
+++ b/lib/elixir_script.ex
@@ -60,7 +60,7 @@ defmodule ElixirScript do
 
   ### JavaScript Interop
 
-  Check out the [JavaScript Interoperability](JavascriptInterop.html) documentation
+  Check out the [JavaScript Interoperability](javascriptinterop.html) documentation
 
   ### Dependencies
 


### PR DESCRIPTION
The link on https://hexdocs.pm/elixir_script/ElixirScript.html is broken; this should fix it.