### PR TITLE
Actually, "yes, console"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,14 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],
   },
+  'overrides': [
+    {
+      'files': ['*spec.js', 'priv/testrunner/**/*'],
+      'rules': {
+        'no-console': 'off'
+      }
+    }
+  ],
   extends: 'airbnb-base',
   plugins: ['import'],
   env: {

--- a/src/javascript/lib/core.js
+++ b/src/javascript/lib/core.js
@@ -27,7 +27,12 @@ function get_global() {
     return global;
   }
 
+  /* As long as the window check precedes this, it won't display in a browser,
+     unless the ground cracks open and swallows JavaScript whole. */
+  /* eslint-disable no-console */
   console.warn('No global state found');
+  /* eslint-enable no-console */
+
   return null;
 }
 

--- a/src/javascript/lib/core/erlang_compat/elixir_errors.js
+++ b/src/javascript/lib/core/erlang_compat/elixir_errors.js
@@ -1,6 +1,10 @@
+/* It is far too "meta" to warn about including a warning in a warning */
+/* eslint-disable no-console */
+
 function warn(message) {
   const messageString = message.join('');
   console.warn(`warning: ${messageString}`);
+
 
   return Symbol.for('ok');
 }

--- a/src/javascript/lib/core/erlang_compat/io.js
+++ b/src/javascript/lib/core/erlang_compat/io.js
@@ -1,3 +1,5 @@
+/* The purpose of this module is, in fact, to do IO. */
+/* eslint-disable no-console */
 import erlang from './erlang';
 
 function put_chars(ioDevice, charData) {

--- a/src/javascript/lib/core/special_forms.js
+++ b/src/javascript/lib/core/special_forms.js
@@ -138,7 +138,10 @@ function _with(...args) {
 }
 
 function receive(clauses, timeout = 0, timeoutFn = () => true) {
+  /* It's more important to warn developers than follow style guides */
+  /* eslint-disable no-console */
   console.warn('Receive not supported');
+  /* eslint-enable no-console */
 
   const messages = []; // this.mailbox.get();
   const NOMATCH = Symbol('NOMATCH');


### PR DESCRIPTION
As discussed in #230!

This includes a change to `.eslintrc.js` and also some individual file changes to selectively disable ESLint's behavior in files where logically a console method does belong, or where the grounding logic of the rule ("avoid cluttering the browser") does not apply.